### PR TITLE
Try to avoid tests failing due to GenServers still running

### DIFF
--- a/test/metrics/workers/counter_test.exs
+++ b/test/metrics/workers/counter_test.exs
@@ -3,13 +3,18 @@ defmodule Metrex.CounterTest do
   import ExUnit.CaptureLog
   alias Metrex.Counter
 
-  @metric "test"
+  @metric "counter_test"
   @test_hooks Metrex.TestHooks
   @hooks Metrex.Hook.Default
 
   setup do
     Application.put_env(:metrex, :hooks, @hooks)
-    Counter.start_link(@metric)
+    case Counter.start_link(@metric) do
+      {:ok, _pid} -> true
+      {:error, reason} ->
+        :timer.sleep(200)
+        Counter.start_link(@metric)
+    end
     :ok
   end
 

--- a/test/metrics/workers/meter_test.exs
+++ b/test/metrics/workers/meter_test.exs
@@ -3,14 +3,19 @@ defmodule Metrex.MeterTest do
   import ExUnit.CaptureLog
   alias Metrex.Meter
 
-  @metric "test"
+  @metric "meter_test"
   @test_hooks Metrex.TestHooks
   @hooks Metrex.Hook.Default
   @ttl Application.get_env(:metrex, :ttl)
 
   setup do
     Application.put_env(:metrex, :hooks, @hooks)
-    Meter.start_link(@metric)
+    case Meter.start_link(@metric) do
+      {:ok, _pid} -> true
+      {:error, {:already_started, _pid}} ->
+        :timer.sleep(200)
+        Meter.start_link(@metric)
+    end
 
     on_exit fn ->
       Metrex.Scheduler.Cleaner.unregister(Metrex.Meter, @metric, @ttl)


### PR DESCRIPTION
Tests sometimes failed sporadically as the previous test's GenServer was still up. This tries to mitigate this by delaying slightly before trying to start a new one if the previous one has not shutdown yet.